### PR TITLE
Add support for NCX

### DIFF
--- a/epubinfo.cabal
+++ b/epubinfo.cabal
@@ -32,6 +32,7 @@ executable epubinfo
       EPUBInfo.Document.Nav
       EPUBInfo.Document.Opf
       EPUBInfo.Monad
+      EPUBInfo.Toc
       EPUBInfo.Utils
       Paths_epubinfo
   hs-source-dirs:

--- a/epubinfo.cabal
+++ b/epubinfo.cabal
@@ -30,6 +30,7 @@ executable epubinfo
       EPUBInfo.Document
       EPUBInfo.Document.Container
       EPUBInfo.Document.Nav
+      EPUBInfo.Document.Ncx
       EPUBInfo.Document.Opf
       EPUBInfo.Monad
       EPUBInfo.Toc

--- a/src/EPUBInfo/Document.hs
+++ b/src/EPUBInfo/Document.hs
@@ -20,6 +20,7 @@ where
 import Control.Monad.Catch (MonadThrow (..))
 import EPUBInfo.Document.Container
 import EPUBInfo.Document.Nav
+import EPUBInfo.Document.Ncx
 import EPUBInfo.Document.Opf
 import EPUBInfo.Monad
 import EPUBInfo.Toc
@@ -54,5 +55,11 @@ getTableOfContents = do
       let navPath = takeDirectory opfPath </> navRelPath
       navDocument <- readNavDocument navPath
       toTableOfContents navDocument
-    Nothing ->
-      throwM EPUBTocItemMissing
+    Nothing -> do
+      mNcxRelPath <- getNcxPathMaybe opfDoc
+      case mNcxRelPath of
+        Just ncxRelPath -> do
+          let ncxPath = takeDirectory opfPath </> ncxRelPath
+          ncxDocument <- readNcxDocument ncxPath
+          toTableOfContents ncxDocument
+        Nothing -> throwM EPUBTocItemMissing

--- a/src/EPUBInfo/Document.hs
+++ b/src/EPUBInfo/Document.hs
@@ -3,6 +3,7 @@ module EPUBInfo.Document
   ( -- * High-level operations
     getMetadata,
     getTableOfContents,
+    EPUBTocItemMissing,
 
     -- * Re-exports
     module EPUBInfo.Document.Opf,
@@ -11,12 +12,14 @@ module EPUBInfo.Document
   )
 where
 
+import Control.Monad.Catch (MonadThrow (..))
 import EPUBInfo.Document.Container
 import EPUBInfo.Document.Nav
 import EPUBInfo.Document.Opf
 import EPUBInfo.Monad
 import Protolude
 import System.FilePath (takeDirectory, (</>))
+import Prelude (Show (..))
 
 -- | Get metadata of the EPUB file.
 getMetadata :: EPUBM EPUBMetadata
@@ -26,11 +29,24 @@ getMetadata =
     >>= readOpfDocument
     >>= getMetadataFromOpf
 
+data EPUBTocItemMissing = EPUBTocItemMissing
+  deriving (Typeable)
+
+instance Show EPUBTocItemMissing where
+  show EPUBTocItemMissing =
+    "The opf document contains neither a navigation document nor a ncx."
+
+instance Exception EPUBTocItemMissing
+
 getTableOfContents :: EPUBM TableOfContents
 getTableOfContents = do
   opfPath <- readContainer >>= getOpfPath
   opfDoc <- readOpfDocument opfPath
-  navRelPath <- getNavDocumentPath opfDoc
-  let navPath = takeDirectory opfPath </> navRelPath
-  navDocument <- readNavDocument navPath
-  toTableOfContents navDocument
+  mNavRelPath <- getNavDocumentPathMaybe opfDoc
+  case mNavRelPath of
+    Just navRelPath -> do
+      let navPath = takeDirectory opfPath </> navRelPath
+      navDocument <- readNavDocument navPath
+      toTableOfContents navDocument
+    Nothing ->
+      throwM EPUBTocItemMissing

--- a/src/EPUBInfo/Document.hs
+++ b/src/EPUBInfo/Document.hs
@@ -6,6 +6,11 @@ module EPUBInfo.Document
     EPUBTocItemMissing,
 
     -- * Re-exports
+    TableOfContents,
+    ToTableOfContents (..),
+    TocRenderOptions (..),
+    tocToOrg,
+    tocToMarkdown,
     module EPUBInfo.Document.Opf,
     module EPUBInfo.Document.Container,
     module EPUBInfo.Document.Nav,
@@ -17,6 +22,7 @@ import EPUBInfo.Document.Container
 import EPUBInfo.Document.Nav
 import EPUBInfo.Document.Opf
 import EPUBInfo.Monad
+import EPUBInfo.Toc
 import Protolude
 import System.FilePath (takeDirectory, (</>))
 import Prelude (Show (..))

--- a/src/EPUBInfo/Document/Nav.hs
+++ b/src/EPUBInfo/Document/Nav.hs
@@ -8,12 +8,12 @@ module EPUBInfo.Document.Nav
   )
 where
 
-import EPUBInfo.Toc
 import Control.Monad.Catch (MonadThrow (..))
 import EPUBInfo.Monad
+import EPUBInfo.Toc
 import Protolude
 import qualified Text.XML.Cursor as C
-import Prelude (Show(..), String)
+import Prelude (Show (..), String)
 
 newtype NavDocument = NavDocument C.Cursor
   deriving (Show)
@@ -46,9 +46,10 @@ instance ToTableOfContents NavDocument where
           [ol] -> TableOfContents <$> xmlToTocNodes ol
           _ -> throwM $ NavOther "The nav element contains multiple children"
 
+navElement :: C.Axis
 navElement =
   C.element "{http://www.w3.org/1999/xhtml}nav"
-  C.>=> C.attributeIs "{http://www.idpf.org/2007/ops}type" "toc"
+    C.>=> C.attributeIs "{http://www.idpf.org/2007/ops}type" "toc"
 
 xmlToTocNodes :: MonadThrow m => C.Cursor -> m [TocNode]
 xmlToTocNodes = goList

--- a/src/EPUBInfo/Document/Ncx.hs
+++ b/src/EPUBInfo/Document/Ncx.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Parsing NCX documents which was supported in EPUB 2.
+module EPUBInfo.Document.Ncx
+  ( NcxDocument,
+    readNcxDocument,
+  )
+where
+
+import Control.Monad.Catch (MonadThrow (..))
+import EPUBInfo.Monad
+import EPUBInfo.Toc
+import Protolude
+import qualified Text.XML.Cursor as C
+import Prelude (String)
+
+newtype NcxDocument = NcxDocument C.Cursor
+  deriving (Show)
+
+readNcxDocument :: FilePath -> EPUBM NcxDocument
+readNcxDocument path = NcxDocument . C.fromDocument <$> readXmlInArchive path
+
+data NcxDocumentException
+  = NcxElementMissing String
+  | NcxLabelTextMissing
+  | NcxLabelContentMissing
+  | NavAttributeMissing String String
+  deriving (Show, Typeable)
+
+instance Exception NcxDocumentException
+
+instance ToTableOfContents NcxDocument where
+  toTableOfContents (NcxDocument root) =
+    case root C.$// C.element "{http://www.daisy.org/z3986/2005/ncx/}navMap" of
+      [] -> throwM $ NcxElementMissing "navMap"
+      (navMapC : _) -> TableOfContents <$> mapM go (navMapC C.$/ navPoint)
+    where
+      go navPointC =
+        TocNode
+          <$> tocEntry navPointC
+          <*> mapM go (navPointC C.$/ navPoint)
+
+tocEntry :: MonadThrow m => C.Cursor -> m TocEntry
+tocEntry navPointC =
+  TocEntry
+    <$> findTitle
+    <*> findSrc
+  where
+    findTitle =
+      case navPointC C.$/ navLabelText of
+        [] -> throwM NcxLabelTextMissing
+        (c : _) -> getLabelText c
+    getLabelText c =
+      case c C.$/ C.content of
+        [] -> throwM NcxLabelContentMissing
+        (text : _) -> return text
+    findSrc =
+      case navPointC C.$/ navContent >=> C.attribute "src" of
+        [] -> throwM $ NavAttributeMissing "content" "src"
+        -- This seems to be a path from the archive root, and not from
+        -- the relative path from the ncx. It can be problematic if
+        -- you use this value, since it is not consistent with the
+        -- specification of the navigation document.
+        (src : _) -> return src
+
+navPoint :: C.Axis
+navPoint = C.element "{http://www.daisy.org/z3986/2005/ncx/}navPoint"
+
+navLabelText :: C.Axis
+navLabelText =
+  C.element "{http://www.daisy.org/z3986/2005/ncx/}navLabel"
+    C.&/ C.element "{http://www.daisy.org/z3986/2005/ncx/}text"
+
+navContent :: C.Axis
+navContent = C.element "{http://www.daisy.org/z3986/2005/ncx/}content"

--- a/src/EPUBInfo/Document/Opf.hs
+++ b/src/EPUBInfo/Document/Opf.hs
@@ -13,6 +13,7 @@ module EPUBInfo.Document.Opf
     readOpfDocument,
     getMetadataFromOpf,
     getNavDocumentPathMaybe,
+    getNcxPathMaybe,
   )
 where
 
@@ -181,6 +182,18 @@ getNavDocumentPathMaybe (OpfDocument root) =
       root
       "item[properties=nav]"
       (item C.>=> C.attributeIs "properties" "nav")
+      "href"
+
+-- | Return href attribute of ncx.
+--
+-- Note that the result will be a relative path from the opf document.
+getNcxPathMaybe :: MonadThrow m => OpfDocument -> m (Maybe FilePath)
+getNcxPathMaybe (OpfDocument root) =
+  fmap unpack
+    <$> lookupItemAttributeInManifest
+      root
+      "item[media-type=application/x-dtbncx+xml]"
+      (item C.>=> C.attributeIs "media-type" "application/x-dtbncx+xml")
       "href"
 
 lookupItemAttributeInManifest ::

--- a/src/EPUBInfo/Toc.hs
+++ b/src/EPUBInfo/Toc.hs
@@ -1,0 +1,64 @@
+-- | Data types for the table of contents of a document
+
+module EPUBInfo.Toc
+  ( -- * Data types
+    TableOfContents(..),
+    TocNode(..),
+    TocEntry(..),
+    -- * Type classes
+    ToTableOfContents(..),
+    -- * Rendering
+    TocRenderOptions(..),
+    tocToOrg,
+    tocToMarkdown,
+  )
+  where
+
+import Control.Monad.Catch (MonadThrow (..))
+import qualified Data.Text as T
+import Protolude
+
+newtype TableOfContents = TableOfContents [TocNode]
+  deriving (Show)
+
+data TocNode = TocNode
+  { tocNodeEntry :: TocEntry,
+    tocNodeChildren :: [TocNode]
+  }
+  deriving (Show)
+
+data TocEntry = TocEntry
+  { tocEntryTitle :: Text,
+    tocEntryHref :: Text
+  }
+  deriving (Show)
+
+class ToTableOfContents a where
+  toTableOfContents :: MonadThrow m => a -> m TableOfContents
+
+data TocRenderOptions = TocRenderOptions
+  { tocCheckbox :: Bool,
+    tocMaxDepth :: Maybe Int
+  }
+  deriving (Show)
+
+tocToOrg :: TocRenderOptions -> TableOfContents -> Text
+tocToOrg opts (TableOfContents nodes) = tocToPlainText "-" 2 opts nodes
+
+tocToMarkdown :: TocRenderOptions -> TableOfContents -> Text
+tocToMarkdown opts (TableOfContents nodes) = tocToPlainText "-" 2 opts nodes
+
+tocToPlainText :: Text -> Int -> TocRenderOptions -> [TocNode] -> Text
+tocToPlainText bullet indentOffset opts = T.intercalate "\n" . map (go 0)
+  where
+    go level (TocNode entry children) =
+      T.concat $
+        [ T.replicate (indentOffset * level) (T.singleton ' '),
+          bullet,
+          if tocCheckbox opts then " [ ]" else T.empty,
+          T.singleton ' ',
+          tocEntryTitle entry
+        ]
+          ++ case tocMaxDepth opts of
+            Just maxDepth | maxDepth == level + 1 -> []
+            _ -> map (T.cons '\n' . go (level + 1)) children


### PR DESCRIPTION
Some EPUB files don't contain a navigation document which is the standard toc format in the EPUB 3 specification. They contain a NCX instead, which is a different toc format previously used in EPUB 2. This PR will add support for the format in the  `toc` command.